### PR TITLE
Feature: Bump datastore to 1.0.0-alpha04

### DIFF
--- a/buildSrc/src/main/java/artifactory-publish-config.gradle.kts
+++ b/buildSrc/src/main/java/artifactory-publish-config.gradle.kts
@@ -8,15 +8,6 @@ plugins {
 artifactory {
   setContextUrl("https://oss.jfrog.org/artifactory")
   withGroovyBuilder {
-    "resolve" {
-      "repository" {
-        setProperty("repoKey", "libs-release")
-        setProperty("username", System.getProperty("artifactoryUser"))
-        setProperty("password", System.getProperty("artifactoryPassword"))
-        setProperty("maven", true)
-      }
-    }
-
     "publish" {
       "repository" {
         if (project.version.toString().endsWith("-SNAPSHOT")) {

--- a/jettheme/src/androidTest/java/dev/lcdsmao/jettheme/ThemeProviderTest.kt
+++ b/jettheme/src/androidTest/java/dev/lcdsmao/jettheme/ThemeProviderTest.kt
@@ -52,11 +52,13 @@ class ThemeProviderTest {
       .assertTextEquals("Default")
       .performClick()
 
+    composeRule.waitForIdle()
     composeRule.onNodeWithTag(TestTag)
       .assertTextEquals("Dark")
       .also { toThemeId = "id_other" }
       .performClick()
 
+    composeRule.waitForIdle()
     composeRule.onNodeWithTag(TestTag)
       .assertTextEquals("Other")
   }
@@ -86,11 +88,13 @@ class ThemeProviderTest {
       .assertTextEquals("Dark")
       .performClick()
 
+    composeRule.waitForIdle()
     composeRule.onNodeWithTag(TestTag)
       .assertTextEquals("Dark")
       .also { toThemeId = "id_other" }
       .performClick()
 
+    composeRule.waitForIdle()
     composeRule.onNodeWithTag(TestTag)
       .assertTextEquals("Other")
   }

--- a/jettheme/src/main/java/dev/lcdsmao/jettheme/internal/PersistentThemeController.kt
+++ b/jettheme/src/main/java/dev/lcdsmao/jettheme/internal/PersistentThemeController.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ContextAmbient
-import androidx.datastore.preferences.preferencesKey
+import androidx.datastore.preferences.core.preferencesKey
 import dev.lcdsmao.jettheme.ThemeConfig
 import dev.lcdsmao.jettheme.ThemeController
 import dev.lcdsmao.jettheme.ThemeIds

--- a/jettheme/src/main/java/dev/lcdsmao/jettheme/internal/ThemeDataStore.kt
+++ b/jettheme/src/main/java/dev/lcdsmao/jettheme/internal/ThemeDataStore.kt
@@ -1,11 +1,11 @@
 package dev.lcdsmao.jettheme.internal
 
 import android.content.Context
-import androidx.datastore.DataStore
-import androidx.datastore.preferences.Preferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.preferencesKey
 import androidx.datastore.preferences.createDataStore
-import androidx.datastore.preferences.edit
-import androidx.datastore.preferences.preferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/jettheme/src/test/java/dev/lcdsmao/jettheme/internal/PersistentThemeControllerTest.kt
+++ b/jettheme/src/test/java/dev/lcdsmao/jettheme/internal/PersistentThemeControllerTest.kt
@@ -1,7 +1,7 @@
 package dev.lcdsmao.jettheme.internal
 
-import androidx.datastore.preferences.Preferences
-import androidx.datastore.preferences.preferencesKey
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.preferencesKey
 import dev.lcdsmao.jettheme.DummyTheme
 import dev.lcdsmao.jettheme.ThemeIds
 import dev.lcdsmao.jettheme.buildThemePack

--- a/versions.properties
+++ b/versions.properties
@@ -33,8 +33,7 @@ version.androidx.core=1.3.2
 ##        # available=1.5.0-alpha04
 ##        # available=1.5.0-alpha05
 
-version.androidx.datastore=1.0.0-alpha02
-##             # available=1.0.0-alpha03
+version.androidx.datastore=1.0.0-alpha04
 
 version.androidx.navigation=1.0.0-alpha02
 
@@ -47,6 +46,7 @@ version.androidx.ui=1.0.0-alpha07
 version.com.jfrog.bintray.gradle..gradle-bintray-plugin=1.8.5
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
+##                                         # available=1.15.0-RC1
 
 version.io.gitlab.arturbosch.detekt..detekt-gradle-plugin=1.14.2
 


### PR DESCRIPTION
## 🚀 Description
- Bump DataStore to 1.0.0-alpha04
- Remove artifactory plugin `resolve` field (error occur when executing `refreshVersions`)

## 📄 Motivation and Context
Bump dependencies version

## 🧪 How Has This Been Tested?
Yes

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.